### PR TITLE
Add icon to Dutch validation ruleset

### DIFF
--- a/netherlands.validator.mapcss
+++ b/netherlands.validator.mapcss
@@ -5,6 +5,7 @@ meta {
     author: "Famlam";
     min-josm-version: "15317"; /* due to tag_regex() usage */
     link: "https://github.com/Famlam/OsmMapcssValidationNL";
+    icon: "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' id='flag-icons-nl' viewBox='0 0 640 480'%3E%3Cpath fill='%2321468b' d='M0 0h640v480H0z'/%3E%3Cpath fill='%23fff' d='M0 0h640v320H0z'/%3E%3Cpath fill='%23ae1c28' d='M0 0h640v160H0z'/%3E%3C/svg%3E%0A";
 }
 /* 
 github: https://github.com/Famlam/OsmMapcssValidationNL


### PR DESCRIPTION
You can open the `data:` content in a browser.

Inspired by the other country-specific rulesets on https://josm.openstreetmap.de/wiki/Rules.